### PR TITLE
Adds typescript support for vue-cal

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "funding": "https://github.com/sponsors/antoniandre",
   "main": "dist/vue-cal.umd.js",
+  "types": "dist/vue-cal.d.ts",
   "module": "dist/vue-cal.es.js",
   "type": "module",
   "files": [
@@ -44,7 +45,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --base /vue-cal/",
-    "build-bundle": "BUNDLE=true vite build",
+    "build-bundle": "BUNDLE=true vite build && cp src/types/* dist/",
     "preview": "vite preview --base /vue-cal/",
     "lint": "vite lint",
     "publish-doc": "npm run build && npm run build-bundle && git add . && git commit -m 'Publish documentation on Github.' && git push && git push --tag"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --base /vue-cal/",
-    "build-bundle": "BUNDLE=true vite build && cp src/types/* dist/",
+    "build-bundle": "BUNDLE=true vite build && cp src/types/vue-cal.ts dist/vue-cal.d.ts",
     "preview": "vite preview --base /vue-cal/",
     "lint": "vite lint",
     "publish-doc": "npm run build && npm run build-bundle && git add . && git commit -m 'Publish documentation on Github.' && git push && git push --tag"

--- a/src/types/vue-cal.d.ts
+++ b/src/types/vue-cal.d.ts
@@ -1,0 +1,74 @@
+import {DefineComponent} from 'vue';
+
+export interface VueCalProps {
+  // HANDLED:
+  clickToNavigate?: boolean, // Setting to false will force it off on date-picker.
+  dark?: boolean, // Dark theme.
+  datePicker?: boolean, // Shorthand for xs: true, views: [month, year, years], clickToNavigate: true.
+  // disableDays: { type: Array, default: () => [] }, // Array of specific dates to disable.
+  // // Can be true false or a finer grain permissions object like:
+  // // { drag: bool, resize: bool, create: bool, delete: bool }
+  // editableEvents: { type: [Boolean, Object], default: false },
+  // // Minimum drag distance in pixels to create an event (prevents accidental event creation when trying to navigate).
+  // eventCreateMinDrag: { type: Number, default: 15 }, // The minimum drag distance in pixels to create an event.
+  // // The array of events to display in Vue Cal.
+  // // Can hold just the view events and be updated or the full array of all events available.
+  // events: { type: Array, default: () => [] },
+  // eventCount: { type: Boolean, default: false }, // Displays an events counter in each cell on month view.
+  // eventsOnMonthView: { type: Boolean, default: false }, // Displays events in full on month view.
+  // hideWeekdays: { type: Array, default: () => [] }, // An array of strings. Possible values: 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'.
+  // hideWeekends: { type: Boolean, default: false }, // Show or hide both Saturday and Sunday in days, week and month views.
+  // // en-us is the default and fallback if locale is not supported.
+  // // The locale can also be provided externally to avoid using Promises.
+  // locale: { type: String, default: '' }, // A language to use for all the texts.
+  // maxDate: { type: [String, Date], default: '' }, // Mostly for date pickers, sets a maximum date for cell interactions.
+  // minDate: { type: [String, Date], default: '' }, // Mostly for date pickers, sets a minimum date for cell interactions.
+  // // A 2-way binding that highlights the selected date in the calendar but does not navigate to it.
+  // selectedDate: { type: [String, Date], default: '' },
+  // sm: { type: Boolean, default: false }, // Small size (truncates texts + specific styles).
+  // specialHours: { type: Object, default: () => ({}) }, // Highlight a particular time range on each day of the week, individually.
+  // schedules: { type: Array, default: () => [] }, // Split a day in different persons/rooms/locations schedules.
+  // snapToInterval: { type: Number, default: 0 }, // Snap the event start and end to a specific interval in minutes.
+  // startWeekOnSunday: { type: Boolean, default: false }, // Shows Sunday before Monday in days, week and month views.
+  // theme: { type: [String, Boolean], default: 'default' }, // Only adds a CSS class when set to default.
+  // time: { type: Boolean, default: true }, // Show or hide the time column.
+  // timeAtCursor: { type: Boolean, default: false }, // Show or hide the "time at cursor" line.
+  // timeCellHeight: { type: Number, default: 40 }, // In pixels.
+  // timeFormat: { type: String, default: '' }, // Overrides the default time format.
+  // timeFrom: { type: Number, default: 0 }, // Start time of the time column, in minutes.
+  // timeStep: { type: Number, default: 60 }, // Step amount for the time in the time column, in minutes.
+  // timeTo: { type: Number, default: minutesInADay }, // End time of the time column, in minutes.
+  // titleBar: { type: Boolean, default: true }, // Show or hide the header title bar.
+  // todayButton: { type: Boolean, default: true }, // Show or hide the header today button.
+  // transitions: { type: Boolean, default: true }, // Enables/disables the navigation transitions.
+  // twelveHour: { type: Boolean, default: false }, // 12 or 24 hour format are respectively written like 1pm and 13:00.
+  // // Sets the calendar view to one of: 'day', 'days', 'week', 'month', 'year', 'years'. Default 'week' or 'month' if datePicker.
+  // // Gets updated on view navigation.
+  // view: { type: String, default: '' },
+  // viewDate: { type: [String, Date], default: '' }, // The view will automatically set its start and end to present this date.
+  // // Only available for month and day views, this will shift the start of the view (left or right) by x days (signed integer).
+  // viewDayOffset: { type: Number, default: 0 },
+  // // The list of all the view that will be available in this calendar.
+  // views: { type: [Array, Object], default: ['day', 'days', 'week', 'month', 'year', 'years'] },
+  // viewsBar: { type: Boolean, default: true }, // Show or hide the headers view selection bar.
+  // watchRealTime: { type: Boolean, default: false }, // More expensive, so only trigger on demand.
+  // weekNumbers: { type: [Boolean, String], default: false }, // Show the weeks numbers in a column on month view.
+  // xs: { type: Boolean, default: false }, // Extra small size for date pickers (truncates texts + specific styles).
+  //
+  // // TODO:
+  // minEventWidth: { type: Number, default: 0 },
+  // minScheduleWidth: { type: Number, default: 0 },
+  // overlapsPerTimeStep: { type: Boolean, default: false },
+  // resizeX: { type: Boolean, default: false },
+  // allDayEvents: { type: [Boolean, String], default: false }
+}
+
+export interface VueCalSlots {
+
+}
+
+export interface VueCalEmits {
+
+}
+
+export declare const VueCal: DefineComponent<VueCalProps, VueCalSlots, VueCalEmits>

--- a/src/types/vue-cal.d.ts
+++ b/src/types/vue-cal.d.ts
@@ -1,66 +1,99 @@
 import {DefineComponent} from 'vue';
 
+type DateString = `${number}${number}${number}${number}-${number}${number}-${number}${number}`
+type DateTimeString = `${DateString} ${number}${number}:${number}${number}`
+
+type Weekdays = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
+type Languages = 'ar' | 'bg' | 'bn' | 'bs' | 'ca' | 'cs' | 'da' | 'de' | 'el' | 'en-gb' | 'en-us' | 'es' | 'et' | 'fa' | 'fi' | 'fr' | 'he' | 'hr' | 'hu' | 'id' | 'is' | 'it' | 'ja' | 'ka' | 'ko' | 'lt' | 'mn' | 'nl' | 'no' | 'pl' | 'pt-br' | 'pt-pt' | 'ro' | 'ru' | 'sk' | 'sl' | 'sq' | 'sr' | 'sv' | 'tr' | 'uk' | 'vi' | 'zh-cn' | 'zh-hk'
+
+type Views = 'day' | 'days' | 'week' | 'month' | 'year' | 'years'
+type ViewsLayout = Partial<Record<Views, {
+    cols: number
+    rows: number
+}>>
+
+type SpecialConfigs = {
+    from: number
+    to: number
+    class: string
+    label?: string
+}
+type SpecialHours = Partial<Record<WeekDays, SpecialConfigs | SpecialConfigs[]>>
+
+type Event = {
+    start: Date,
+    end: Date,
+    id?: string,
+    title?: string,
+    draggable?: boolean,
+    resizable?: boolean,
+    deletable?: boolean,
+    allDay?: boolean,
+    recurring?: number,
+    schedule?: number,
+    background?: number,
+    class?: string
+}
+
 export interface VueCalProps {
   // HANDLED:
   clickToNavigate?: boolean, // Setting to false will force it off on date-picker.
   dark?: boolean, // Dark theme.
   datePicker?: boolean, // Shorthand for xs: true, views: [month, year, years], clickToNavigate: true.
-  // disableDays: { type: Array, default: () => [] }, // Array of specific dates to disable.
+  disableDays?: (Date | DateString)[], // Array of specific dates to disable.
   // // Can be true false or a finer grain permissions object like:
   // // { drag: bool, resize: bool, create: bool, delete: bool }
-  // editableEvents: { type: [Boolean, Object], default: false },
-  // // Minimum drag distance in pixels to create an event (prevents accidental event creation when trying to navigate).
-  // eventCreateMinDrag: { type: Number, default: 15 }, // The minimum drag distance in pixels to create an event.
-  // // The array of events to display in Vue Cal.
-  // // Can hold just the view events and be updated or the full array of all events available.
-  // events: { type: Array, default: () => [] },
-  // eventCount: { type: Boolean, default: false }, // Displays an events counter in each cell on month view.
-  // eventsOnMonthView: { type: Boolean, default: false }, // Displays events in full on month view.
-  // hideWeekdays: { type: Array, default: () => [] }, // An array of strings. Possible values: 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'.
-  // hideWeekends: { type: Boolean, default: false }, // Show or hide both Saturday and Sunday in days, week and month views.
-  // // en-us is the default and fallback if locale is not supported.
-  // // The locale can also be provided externally to avoid using Promises.
-  // locale: { type: String, default: '' }, // A language to use for all the texts.
-  // maxDate: { type: [String, Date], default: '' }, // Mostly for date pickers, sets a maximum date for cell interactions.
-  // minDate: { type: [String, Date], default: '' }, // Mostly for date pickers, sets a minimum date for cell interactions.
-  // // A 2-way binding that highlights the selected date in the calendar but does not navigate to it.
-  // selectedDate: { type: [String, Date], default: '' },
-  // sm: { type: Boolean, default: false }, // Small size (truncates texts + specific styles).
-  // specialHours: { type: Object, default: () => ({}) }, // Highlight a particular time range on each day of the week, individually.
+  editableEvents?: boolean | { drag: boolean, resize: boolean, create: boolean, delete: boolean },
+  // Minimum drag distance in pixels to create an event (prevents accidental event creation when trying to navigate).
+  eventCreateMinDrag?: number, // The minimum drag distance in pixels to create an event.
+  // The array of events to display in Vue Cal.
+  // Can hold just the view events and be updated or the full array of all events available.
+  events?: Event[],
+  eventCount?: boolean, // Displays an events counter in each cell on month view.
+  eventsOnMonthView?: boolean, // Displays events in full on month view.
+  hideWeekdays?: Weekdays[], // An array of strings. Possible values: 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'.
+  hideWeekends?: boolean, // Show or hide both Saturday and Sunday in days, week and month views.
+  // en-us is the default and fallback if locale is not supported.
+  // The locale can also be provided externally to avoid using Promises.
+  locale?: Languages, // A language to use for all the texts.
+  maxDate?: Date | DateString | DateTimeString, // Mostly for date pickers, sets a maximum date for cell interactions.
+  minDate?: Date | DateString | DateTimeString, // Mostly for date pickers, sets a minimum date for cell interactions.
+  // A 2-way binding that highlights the selected date in the calendar but does not navigate to it.
+  selectedDate?: (Date | DateString),
+  sm?: boolean, // Small size (truncates texts + specific styles).
+  specialHours?: SpecialHours, // Highlight a particular time range on each day of the week, individually.
   // schedules: { type: Array, default: () => [] }, // Split a day in different persons/rooms/locations schedules.
-  // snapToInterval: { type: Number, default: 0 }, // Snap the event start and end to a specific interval in minutes.
-  // startWeekOnSunday: { type: Boolean, default: false }, // Shows Sunday before Monday in days, week and month views.
+  snapToInterval?: number, // Snap the event start and end to a specific interval in minutes.
+  startWeekOnSunday?: boolean, // Shows Sunday before Monday in days, week and month views.
   // theme: { type: [String, Boolean], default: 'default' }, // Only adds a CSS class when set to default.
-  // time: { type: Boolean, default: true }, // Show or hide the time column.
-  // timeAtCursor: { type: Boolean, default: false }, // Show or hide the "time at cursor" line.
-  // timeCellHeight: { type: Number, default: 40 }, // In pixels.
-  // timeFormat: { type: String, default: '' }, // Overrides the default time format.
-  // timeFrom: { type: Number, default: 0 }, // Start time of the time column, in minutes.
-  // timeStep: { type: Number, default: 60 }, // Step amount for the time in the time column, in minutes.
-  // timeTo: { type: Number, default: minutesInADay }, // End time of the time column, in minutes.
-  // titleBar: { type: Boolean, default: true }, // Show or hide the header title bar.
-  // todayButton: { type: Boolean, default: true }, // Show or hide the header today button.
-  // transitions: { type: Boolean, default: true }, // Enables/disables the navigation transitions.
-  // twelveHour: { type: Boolean, default: false }, // 12 or 24 hour format are respectively written like 1pm and 13:00.
-  // // Sets the calendar view to one of: 'day', 'days', 'week', 'month', 'year', 'years'. Default 'week' or 'month' if datePicker.
-  // // Gets updated on view navigation.
-  // view: { type: String, default: '' },
-  // viewDate: { type: [String, Date], default: '' }, // The view will automatically set its start and end to present this date.
-  // // Only available for month and day views, this will shift the start of the view (left or right) by x days (signed integer).
-  // viewDayOffset: { type: Number, default: 0 },
-  // // The list of all the view that will be available in this calendar.
-  // views: { type: [Array, Object], default: ['day', 'days', 'week', 'month', 'year', 'years'] },
-  // viewsBar: { type: Boolean, default: true }, // Show or hide the headers view selection bar.
-  // watchRealTime: { type: Boolean, default: false }, // More expensive, so only trigger on demand.
-  // weekNumbers: { type: [Boolean, String], default: false }, // Show the weeks numbers in a column on month view.
-  // xs: { type: Boolean, default: false }, // Extra small size for date pickers (truncates texts + specific styles).
-  //
-  // // TODO:
-  // minEventWidth: { type: Number, default: 0 },
-  // minScheduleWidth: { type: Number, default: 0 },
-  // overlapsPerTimeStep: { type: Boolean, default: false },
-  // resizeX: { type: Boolean, default: false },
-  // allDayEvents: { type: [Boolean, String], default: false }
+  time?: boolean, // Show or hide the time column.
+  timeAtCursor?: boolean, // Show or hide the "time at cursor" line.
+  timeCellHeight?: number, // In pixels.
+  timeFormat?: string, // Overrides the default time format.
+  timeFrom?: number, // Start time of the time column, in minutes.
+  timeStep?: number, // Step amount for the time in the time column, in minutes.
+  timeTo?: number, // End time of the time column, in minutes.
+  titleBar?: boolean, // Show or hide the header title bar.
+  todayButton?: boolean, // Show or hide the header today button.
+  transitions?: boolean, // Enables/disables the navigation transitions.
+  twelveHour?: boolean, // 12 or 24 hour format are respectively written like 1pm and 13:00.
+  // Sets the calendar view to one of: 'day', 'days', 'week', 'month', 'year', 'years'. Default 'week' or 'month' if datePicker.
+  // Gets updated on view navigation.
+  view?: Views | ViewsLayout,
+  viewDate?: Date | DateString, // The view will automatically set its start and end to present this date.
+  // Only available for month and day views, this will shift the start of the view (left or right) by x days (signed integer).
+  viewDayOffset?: number,
+  // The list of all the view that will be available in this calendar.
+  views?: Views[] | ViewsLayout,
+  viewsBar?: boolean, // Show or hide the headers view selection bar.
+  watchRealTime?: false, // More expensive, so only trigger on demand.
+  weekNumbers?: boolean, // Show the weeks numbers in a column on month view.
+  xs?: boolean, // Extra small size for date pickers (truncates texts + specific styles).
+  minEventWidth?: number,
+  minScheduleWidth?: number,
+  overlapsPerTimeStep?: boolean,
+  resizeX?: boolean,
+  allDayEvents?: { type: [Boolean, String], default: false }
 }
 
 export interface VueCalSlots {

--- a/src/types/vue-cal.d.ts
+++ b/src/types/vue-cal.d.ts
@@ -1,26 +1,29 @@
-import {DefineComponent} from 'vue';
+import {
+  Ref,
+  DefineSetupFnComponent
+} from 'vue';
 
-type DateString = `${number}${number}${number}${number}-${number}${number}-${number}${number}`
-type DateTimeString = `${DateString} ${number}${number}:${number}${number}`
+type VueCalDateString = `${number}${number}${number}${number}-${number}${number}-${number}${number}`
+type VueCalDateTimeString = `${VueCalDateString} ${number}${number}:${number}${number}`
 
-type Weekdays = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
-type Languages = 'ar' | 'bg' | 'bn' | 'bs' | 'ca' | 'cs' | 'da' | 'de' | 'el' | 'en-gb' | 'en-us' | 'es' | 'et' | 'fa' | 'fi' | 'fr' | 'he' | 'hr' | 'hu' | 'id' | 'is' | 'it' | 'ja' | 'ka' | 'ko' | 'lt' | 'mn' | 'nl' | 'no' | 'pl' | 'pt-br' | 'pt-pt' | 'ro' | 'ru' | 'sk' | 'sl' | 'sq' | 'sr' | 'sv' | 'tr' | 'uk' | 'vi' | 'zh-cn' | 'zh-hk'
+type VueCalWeekdays = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
+type VueCalLanguages = 'ar' | 'bg' | 'bn' | 'bs' | 'ca' | 'cs' | 'da' | 'de' | 'el' | 'en-gb' | 'en-us' | 'es' | 'et' | 'fa' | 'fi' | 'fr' | 'he' | 'hr' | 'hu' | 'id' | 'is' | 'it' | 'ja' | 'ka' | 'ko' | 'lt' | 'mn' | 'nl' | 'no' | 'pl' | 'pt-br' | 'pt-pt' | 'ro' | 'ru' | 'sk' | 'sl' | 'sq' | 'sr' | 'sv' | 'tr' | 'uk' | 'vi' | 'zh-cn' | 'zh-hk'
 
-type Views = 'day' | 'days' | 'week' | 'month' | 'year' | 'years'
-type ViewsLayout = Partial<Record<Views, {
+type VueCalViewKeys = 'day' | 'days' | 'week' | 'month' | 'year' | 'years'
+type VueCalViewsLayout = Partial<Record<VueCalViewKeys, {
     cols: number
     rows: number
 }>>
 
-type SpecialConfigs = {
+export interface VueCalSpecialHoursConfigs {
     from: number
     to: number
     class: string
     label?: string
 }
-type SpecialHours = Partial<Record<WeekDays, SpecialConfigs | SpecialConfigs[]>>
+type VueCalSpecialHours = Partial<Record<VueCalWeekdays, VueCalSpecialHoursConfigs | VueCalSpecialHoursConfigs[]>>
 
-type Event = {
+export interface VueCalEvent {
     start: Date,
     end: Date,
     id?: string,
@@ -29,18 +32,18 @@ type Event = {
     resizable?: boolean,
     deletable?: boolean,
     allDay?: boolean,
-    recurring?: number,
+    // recurring?: number,
     schedule?: number,
     background?: number,
     class?: string
 }
 
-export interface VueCalProps {
+export interface VueCalConfig {
   // HANDLED:
   clickToNavigate?: boolean, // Setting to false will force it off on date-picker.
   dark?: boolean, // Dark theme.
   datePicker?: boolean, // Shorthand for xs: true, views: [month, year, years], clickToNavigate: true.
-  disableDays?: (Date | DateString)[], // Array of specific dates to disable.
+  disableDays?: (Date | VueCalDateString)[], // Array of specific dates to disable.
   // // Can be true false or a finer grain permissions object like:
   // // { drag: bool, resize: bool, create: bool, delete: bool }
   editableEvents?: boolean | { drag: boolean, resize: boolean, create: boolean, delete: boolean },
@@ -48,20 +51,20 @@ export interface VueCalProps {
   eventCreateMinDrag?: number, // The minimum drag distance in pixels to create an event.
   // The array of events to display in Vue Cal.
   // Can hold just the view events and be updated or the full array of all events available.
-  events?: Event[],
+  events?: VueCalEvent[],
   eventCount?: boolean, // Displays an events counter in each cell on month view.
   eventsOnMonthView?: boolean, // Displays events in full on month view.
-  hideWeekdays?: Weekdays[], // An array of strings. Possible values: 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'.
+  hideWeekdays?: VueCalWeekdays[], // An array of strings. Possible values: 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'.
   hideWeekends?: boolean, // Show or hide both Saturday and Sunday in days, week and month views.
   // en-us is the default and fallback if locale is not supported.
   // The locale can also be provided externally to avoid using Promises.
-  locale?: Languages, // A language to use for all the texts.
-  maxDate?: Date | DateString | DateTimeString, // Mostly for date pickers, sets a maximum date for cell interactions.
-  minDate?: Date | DateString | DateTimeString, // Mostly for date pickers, sets a minimum date for cell interactions.
+  locale?: VueCalLanguages, // A language to use for all the texts.
+  maxDate?: Date | VueCalDateString | VueCalDateTimeString, // Mostly for date pickers, sets a maximum date for cell interactions.
+  minDate?: Date | VueCalDateString | VueCalDateTimeString, // Mostly for date pickers, sets a minimum date for cell interactions.
   // A 2-way binding that highlights the selected date in the calendar but does not navigate to it.
-  selectedDate?: (Date | DateString),
+  selectedDate?: (Date | VueCalDateString),
   sm?: boolean, // Small size (truncates texts + specific styles).
-  specialHours?: SpecialHours, // Highlight a particular time range on each day of the week, individually.
+  specialHours?: VueCalSpecialHours, // Highlight a particular time range on each day of the week, individually.
   // schedules: { type: Array, default: () => [] }, // Split a day in different persons/rooms/locations schedules.
   snapToInterval?: number, // Snap the event start and end to a specific interval in minutes.
   startWeekOnSunday?: boolean, // Shows Sunday before Monday in days, week and month views.
@@ -75,16 +78,15 @@ export interface VueCalProps {
   timeTo?: number, // End time of the time column, in minutes.
   titleBar?: boolean, // Show or hide the header title bar.
   todayButton?: boolean, // Show or hide the header today button.
-  transitions?: boolean, // Enables/disables the navigation transitions.
   twelveHour?: boolean, // 12 or 24 hour format are respectively written like 1pm and 13:00.
   // Sets the calendar view to one of: 'day', 'days', 'week', 'month', 'year', 'years'. Default 'week' or 'month' if datePicker.
   // Gets updated on view navigation.
-  view?: Views | ViewsLayout,
-  viewDate?: Date | DateString, // The view will automatically set its start and end to present this date.
+  view?: VueCalViewKeys | VueCalViewsLayout,
+  viewDate?: Date | VueCalDateString, // The view will automatically set its start and end to present this date.
   // Only available for month and day views, this will shift the start of the view (left or right) by x days (signed integer).
   viewDayOffset?: number,
   // The list of all the view that will be available in this calendar.
-  views?: Views[] | ViewsLayout,
+  views?: VueCalViewKeys[] | VueCalViewsLayout,
   viewsBar?: boolean, // Show or hide the headers view selection bar.
   watchRealTime?: false, // More expensive, so only trigger on demand.
   weekNumbers?: boolean, // Show the weeks numbers in a column on month view.
@@ -96,12 +98,109 @@ export interface VueCalProps {
   allDayEvents?: { type: [Boolean, String], default: false }
 }
 
+export interface VueCalView {
+  // ID, Title
+  id: VueCalViewKeys
+  title: string
+  // Ranges
+  start: Date
+  end: Date
+  extendedStart: Date
+  extendedEnd: Date
+  // Cell dates
+  cellDates: {
+      start: Date,
+      end: Date,
+      startFormatted: VueCalDateString
+  }[],
+  // Events
+  events: Record<VueCalDateString, Ref<VueCalEvent>[]>
+  // Methods
+  switch: (view: VueCalViewKeys) => void
+  broader: () => void
+  narrower: () => void
+  previous: () => void
+  next: () => void
+  goToToday: () => void
+  updateViewDate: (date: Date) => void
+  updateSelectedDate: (date: Date) => void
+  createEvent: (event: VueCalEvent) => void
+  deleteEvent: (eventId: number | object, forceStage?: number) => void
+  scrollToCurrentTime: () => void
+  scrollToTime: (minutes: number) => void
+  scrollTop: () => void
+  // Others
+  viewDate: Date
+  selectedDate: Date
+  now: Date
+  containsToday: boolean
+  cols: number
+  rows: number
+  isDay: boolean
+  isDays: boolean
+  isWeek: boolean
+  isMonth: boolean
+  isYear: boolean
+  isYears: boolean
+}
+
+export interface VueCalCell {
+  broader: VueCalViewKeys
+  narrower: VueCalViewsKeys
+  goBroader: () => void
+  goNarrower: () => void
+  start: Date
+  end: Date
+}
+
+export interface VueCalCellEvents {
+  cell: VueCalCell
+  cursor: {
+    x: number
+    y: number
+    date: Date
+  }
+  e: PointerEvent
+}
+
+export interface VueCalEventEvents {
+  event: VueCalEvent
+  e: PointerEvent
+}
+
 export interface VueCalSlots {
 
 }
 
-export interface VueCalEmits {
+export interface VueCalEmits extends Record<string, ((...args: any[]) => any)> {
+  // Core Events
+  'ready': (value: { config: VueCalConfig, view: VueCalView }) => any
+  'viewChange': (value: VueCalView) => any // possible change to custom view
+  'update:view': (value: VueCalViewKeys) => any
+  'update:selectedDate': (value: Date) => any
+  'update:viewDate': (value: Date) => any
+  'update:events': (value: VueCalEvent[]) => any
+  // Cell-related Events
+  'cell-click': (value: VueCalCellEvents) => any
+  'cell-drag-start': (value: VueCalCellEvents) => any
+  'cell-drag': (value: VueCalCellEvents) => any
+  'cell-drag-end': (value: VueCalCellEvents) => any
+  'cell-hold': (value: VueCalCellEvents) => any
+  // Event-related Events
+  'event-hold': (value: VueCalEventEvents) => any
+  'event-create': (value: VueCalEventEvents & VueCalCellEvents) => any
+  'event-created': (value: VueCalEventEvents) => any
+  'event-delete': (value: VueCalEvent) => any
+  'event-dropped': (value: {originalEvent: VueCalEvent, event: VueCalEvent}) => any
+  'event-drag-start': (value: VueCalEventEvents) => any
+  'event-drag': (value: VueCalEventEvents) => any
+  'event-drag-end': (value: VueCalEventEvents) => any
+  'event-resize-start': (value: VueCalEventEvents) => any
+  'event-resize': (value: { _eid: number, end: Date, endTimeMinutes }) => any
+  'event-resize-end': (value: VueCalEventEvents) => any
 
+  // 'event-change': []
+  // 'event-drag-start', 'event-drag-end', 'event-resize-start', 'event-resize-end'
 }
 
-export declare const VueCal: DefineComponent<VueCalProps, VueCalSlots, VueCalEmits>
+export declare const VueCal: DefineSetupFnComponent<VueCalConfig, VueCalEmits>

--- a/src/types/vue-cal.d.ts
+++ b/src/types/vue-cal.d.ts
@@ -204,3 +204,26 @@ export interface VueCalEmits extends Record<string, ((...args: any[]) => any)> {
 }
 
 export declare const VueCal: DefineSetupFnComponent<VueCalConfig, VueCalEmits>
+
+
+export declare function addDatePrototypes(): void
+
+declare global {
+  interface Date {
+    addDays(days: number): Date
+    addHours(hours: number): Date
+    addMinutes(minutes: number): Date
+    
+    subtractDays(days: number): Date
+    subtractHours(hours: number): Date
+    subtractMinutes(minutes: number): Date
+    
+    getWeek(): number
+    isToday(): boolean
+    isLeapYear(): boolean
+    
+    format(format: string): string
+    formatTime(format: string): string
+  }
+}
+

--- a/src/types/vue-cal.ts
+++ b/src/types/vue-cal.ts
@@ -133,7 +133,7 @@ export interface VueCalConfig {
   snapToInterval?: number, // Snap the event start and end to a specific interval in minutes.
   startWeekOnSunday?: boolean, // Shows Sunday before Monday in days, week and month views.
   stackEvents?: boolean,
-  theme?: boolean | 'default',
+  theme?: boolean | string,
   time?: boolean, // Show or hide the time column.
   timeCellHeight?: number, // In pixels.
   timeFormat?: string, // Overrides the default time format.

--- a/src/types/vue-cal.ts
+++ b/src/types/vue-cal.ts
@@ -1,5 +1,4 @@
 import {
-  Ref,
   DefineSetupFnComponent
 } from 'vue';
 
@@ -7,53 +6,118 @@ type VueCalDateString = `${number}${number}${number}${number}-${number}${number}
 type VueCalDateTimeString = `${VueCalDateString} ${number}${number}:${number}${number}`
 
 type VueCalWeekdays = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
-type VueCalLanguages = 'ar' | 'bg' | 'bn' | 'bs' | 'ca' | 'cs' | 'da' | 'de' | 'el' | 'en-gb' | 'en-us' | 'es' | 'et' | 'fa' | 'fi' | 'fr' | 'he' | 'hr' | 'hu' | 'id' | 'is' | 'it' | 'ja' | 'ka' | 'ko' | 'lt' | 'mn' | 'nl' | 'no' | 'pl' | 'pt-br' | 'pt-pt' | 'ro' | 'ru' | 'sk' | 'sl' | 'sq' | 'sr' | 'sv' | 'tr' | 'uk' | 'vi' | 'zh-cn' | 'zh-hk'
+type VueCalLanguages =
+  'ar'
+  | 'bg'
+  | 'bn'
+  | 'bs'
+  | 'ca'
+  | 'cs'
+  | 'da'
+  | 'de'
+  | 'el'
+  | 'en-gb'
+  | 'en-us'
+  | 'es'
+  | 'et'
+  | 'fa'
+  | 'fi'
+  | 'fr'
+  | 'he'
+  | 'hr'
+  | 'hu'
+  | 'id'
+  | 'is'
+  | 'it'
+  | 'ja'
+  | 'kaa'
+  | 'ka'
+  | 'kk'
+  | 'ko'
+  | 'ky'
+  | 'lt'
+  | 'mn'
+  | 'nl'
+  | 'no'
+  | 'pl'
+  | 'pt-br'
+  | 'pt-pt'
+  | 'ro'
+  | 'ru'
+  | 'sk'
+  | 'sl'
+  | 'sq'
+  | 'sr'
+  | 'sv'
+  | 'tr'
+  | 'uk'
+  | 'uz'
+  | 'uz-cryl'
+  | 'vi'
+  | 'zh-cn'
+  | 'zh-hk'
 
 type VueCalViewKeys = 'day' | 'days' | 'week' | 'month' | 'year' | 'years'
 type VueCalViewsLayout = Partial<Record<VueCalViewKeys, {
-    cols: number
-    rows: number
+  cols: number
+  rows: number
 }>>
 
 export interface VueCalSpecialHoursConfigs {
-    from: number
-    to: number
-    class: string
-    label?: string
+  from: number
+  to: number
+  class: string
+  label?: string
 }
+
 type VueCalSpecialHours = Partial<Record<VueCalWeekdays, VueCalSpecialHoursConfigs | VueCalSpecialHoursConfigs[]>>
 
+export type VueCalSchedules = {
+  id?: number
+  class?: string
+  label?: string
+  hide?: false
+}
+export type VueCalSchedulesHidden = {
+  id: number
+  class?: string
+  label?: string
+  hide?: boolean
+}
+
 export interface VueCalEvent {
-    start: Date,
-    end: Date,
-    id?: string,
-    title?: string,
-    draggable?: boolean,
-    resizable?: boolean,
-    deletable?: boolean,
-    allDay?: boolean,
-    // recurring?: number,
-    schedule?: number,
-    background?: number,
-    class?: string
+  _eid?: undefined,
+  _?: undefined,
+  start: Date | VueCalDateTimeString,
+  end: Date | VueCalDateTimeString,
+  id?: string,
+  title?: string,
+  content?: string
+  class?: string,
+  background?: number,
+  schedule?: number,
+  allDay?: boolean,
+  resizable?: boolean,
+  draggable?: boolean,
+  deletable?: boolean,
 }
 
 export interface VueCalConfig {
-  // HANDLED:
+  allDayEvents?: boolean,
   clickToNavigate?: boolean, // Setting to false will force it off on date-picker.
   dark?: boolean, // Dark theme.
   datePicker?: boolean, // Shorthand for xs: true, views: [month, year, years], clickToNavigate: true.
   disableDays?: (Date | VueCalDateString)[], // Array of specific dates to disable.
   // // Can be true false or a finer grain permissions object like:
   // // { drag: bool, resize: bool, create: bool, delete: bool }
-  editableEvents?: boolean | { drag: boolean, resize: boolean, create: boolean, delete: boolean },
-  // Minimum drag distance in pixels to create an event (prevents accidental event creation when trying to navigate).
-  eventCreateMinDrag?: number, // The minimum drag distance in pixels to create an event.
+  editableEvents?: boolean | { drag?: boolean, resize?: boolean, create?: boolean, delete?: boolean },
   // The array of events to display in Vue Cal.
   // Can hold just the view events and be updated or the full array of all events available.
+  eventCount?: boolean | VueCalViewKeys[], // Displays an events counter in each cell on month view.
   events?: VueCalEvent[],
-  eventCount?: boolean, // Displays an events counter in each cell on month view.
-  eventsOnMonthView?: boolean, // Displays events in full on month view.
+  // Minimum drag distance in pixels to create an event (prevents accidental event creation when trying to navigate).
+  eventCreateMinDrag?: number, // The minimum drag distance in pixels to create an event.
+  eventsOnMonthView?: boolean | 'short', // Displays events in full on month view.
   hideWeekdays?: VueCalWeekdays[], // An array of strings. Possible values: 'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'.
   hideWeekends?: boolean, // Show or hide both Saturday and Sunday in days, week and month views.
   // en-us is the default and fallback if locale is not supported.
@@ -62,15 +126,15 @@ export interface VueCalConfig {
   maxDate?: Date | VueCalDateString | VueCalDateTimeString, // Mostly for date pickers, sets a maximum date for cell interactions.
   minDate?: Date | VueCalDateString | VueCalDateTimeString, // Mostly for date pickers, sets a minimum date for cell interactions.
   // A 2-way binding that highlights the selected date in the calendar but does not navigate to it.
-  selectedDate?: (Date | VueCalDateString),
+  selectedDate?: (Date | VueCalDateString | VueCalDateTimeString),
   sm?: boolean, // Small size (truncates texts + specific styles).
   specialHours?: VueCalSpecialHours, // Highlight a particular time range on each day of the week, individually.
-  // schedules: { type: Array, default: () => [] }, // Split a day in different persons/rooms/locations schedules.
+  schedules?: VueCalSchedules[] | VueCalSchedulesHidden[], // Split a day in different persons/rooms/locations schedules.
   snapToInterval?: number, // Snap the event start and end to a specific interval in minutes.
   startWeekOnSunday?: boolean, // Shows Sunday before Monday in days, week and month views.
-  // theme: { type: [String, Boolean], default: 'default' }, // Only adds a CSS class when set to default.
+  stackEvents?: boolean,
+  theme?: boolean | 'default',
   time?: boolean, // Show or hide the time column.
-  timeAtCursor?: boolean, // Show or hide the "time at cursor" line.
   timeCellHeight?: number, // In pixels.
   timeFormat?: string, // Overrides the default time format.
   timeFrom?: number, // Start time of the time column, in minutes.
@@ -81,8 +145,8 @@ export interface VueCalConfig {
   twelveHour?: boolean, // 12 or 24 hour format are respectively written like 1pm and 13:00.
   // Sets the calendar view to one of: 'day', 'days', 'week', 'month', 'year', 'years'. Default 'week' or 'month' if datePicker.
   // Gets updated on view navigation.
-  view?: VueCalViewKeys | VueCalViewsLayout,
-  viewDate?: Date | VueCalDateString, // The view will automatically set its start and end to present this date.
+  view?: VueCalViewKeys,
+  viewDate?: Date | VueCalDateString | VueCalDateTimeString, // The view will automatically set its start and end to present this date.
   // Only available for month and day views, this will shift the start of the view (left or right) by x days (signed integer).
   viewDayOffset?: number,
   // The list of all the view that will be available in this calendar.
@@ -91,11 +155,6 @@ export interface VueCalConfig {
   watchRealTime?: false, // More expensive, so only trigger on demand.
   weekNumbers?: boolean, // Show the weeks numbers in a column on month view.
   xs?: boolean, // Extra small size for date pickers (truncates texts + specific styles).
-  minEventWidth?: number,
-  minScheduleWidth?: number,
-  overlapsPerTimeStep?: boolean,
-  resizeX?: boolean,
-  allDayEvents?: { type: [Boolean, String], default: false }
 }
 
 export interface VueCalView {
@@ -105,18 +164,18 @@ export interface VueCalView {
   // Ranges
   start: Date
   end: Date
-  extendedStart: Date
-  extendedEnd: Date
+  fullRangeStart: Date
+  fullRangeEnd: Date
   // Cell dates
   cellDates: {
-      start: Date,
-      end: Date,
-      startFormatted: VueCalDateString
+    start: Date,
+    end: Date,
+    startFormatted: VueCalDateString
   }[],
   // Events
-  events: Record<VueCalDateString, Ref<VueCalEvent>[]>
+  events: VueCalEvent[]
   // Methods
-  switch: (view: VueCalViewKeys) => void
+  switch: (view: VueCalViewKeys, date?: Date) => void
   broader: () => void
   narrower: () => void
   previous: () => void
@@ -125,7 +184,7 @@ export interface VueCalView {
   updateViewDate: (date: Date) => void
   updateSelectedDate: (date: Date) => void
   createEvent: (event: VueCalEvent) => void
-  deleteEvent: (eventId: number | object, forceStage?: number) => void
+  deleteEvent: (eventId: number, forceStage?: number) => void
   scrollToCurrentTime: () => void
   scrollToTime: (minutes: number) => void
   scrollTop: () => void
@@ -133,6 +192,7 @@ export interface VueCalView {
   viewDate: Date
   selectedDate: Date
   now: Date
+  broaderView: VueCalViewKeys
   containsToday: boolean
   cols: number
   rows: number
@@ -146,7 +206,7 @@ export interface VueCalView {
 
 export interface VueCalCell {
   broader: VueCalViewKeys
-  narrower: VueCalViewsKeys
+  narrower: VueCalViewKeys
   goBroader: () => void
   goNarrower: () => void
   start: Date
@@ -168,10 +228,6 @@ export interface VueCalEventEvents {
   e: PointerEvent
 }
 
-export interface VueCalSlots {
-
-}
-
 export interface VueCalEmits extends Record<string, ((...args: any[]) => any)> {
   // Core Events
   'ready': (value: { config: VueCalConfig, view: VueCalView }) => any
@@ -191,16 +247,14 @@ export interface VueCalEmits extends Record<string, ((...args: any[]) => any)> {
   'event-create': (value: VueCalEventEvents & VueCalCellEvents) => any
   'event-created': (value: VueCalEventEvents) => any
   'event-delete': (value: VueCalEvent) => any
-  'event-dropped': (value: {originalEvent: VueCalEvent, event: VueCalEvent}) => any
   'event-drag-start': (value: VueCalEventEvents) => any
   'event-drag': (value: VueCalEventEvents) => any
   'event-drag-end': (value: VueCalEventEvents) => any
   'event-resize-start': (value: VueCalEventEvents) => any
-  'event-resize': (value: { _eid: number, end: Date, endTimeMinutes }) => any
-  'event-resize-end': (value: VueCalEventEvents) => any
-
-  // 'event-change': []
-  // 'event-drag-start', 'event-drag-end', 'event-resize-start', 'event-resize-end'
+  'event-resize': (value: VueCalEventEvents & {overlaps: VueCalEvent[]}) => any
+  'event-resize-end': (value: VueCalEventEvents & {original: VueCalEvent, overlaps: VueCalEvent[]}) => any
+  'event-drop': (value: VueCalEventEvents & {overlaps: VueCalEvent[], cell: VueCalCell, external: boolean}) => any
+  'event-dropped': (value: VueCalEventEvents & {originalEvent: VueCalEvent, cell: VueCalCell, external: boolean}) => any
 }
 
 export declare const VueCal: DefineSetupFnComponent<VueCalConfig, VueCalEmits>
@@ -211,18 +265,25 @@ export declare function addDatePrototypes(): void
 declare global {
   interface Date {
     addDays(days: number): Date
+
     addHours(hours: number): Date
+
     addMinutes(minutes: number): Date
-    
+
     subtractDays(days: number): Date
+
     subtractHours(hours: number): Date
+
     subtractMinutes(minutes: number): Date
-    
+
     getWeek(): number
+
     isToday(): boolean
+
     isLeapYear(): boolean
-    
+
     format(format: string): string
+
     formatTime(format: string): string
   }
 }


### PR DESCRIPTION
Supports Properties and Emits according to the documentation.
(Ignores event-* and cell-* emits as they cannot be mapped properly in typescript)

Also supports [Date Prototypes](https://antoniandre.github.io/vue-cal/date-prototypes) thanks to @xontik

Adds a single .ts file containing all the definitions, linked as the according type file in package.json.
In build-bundle simply copies the type file into the shipped bundle.
Hope this is separated enough for you @antoniandre