### PR TITLE
fix: check events overlap after schedules change with the same events

### DIFF
--- a/src/vue-cal/components/cell.vue
+++ b/src/vue-cal/components/cell.vue
@@ -667,13 +667,17 @@ const recalculateOverlaps = () => {
 
 watch(
   // Watch event IDs and start/end dates (only) to detect event resizing/dnd.
-  () => !view.isYears && !view.isYear && cellForegroundEvents.value.map(e => `${e._.id}${e.start.getTime()}${e.end.getTime()}`).join(),
+  // Also check if the schedules change in case the events are the same
+  [
+    () => !view.isYears && !view.isYear && cellForegroundEvents.value.map(e => `${e._.id}${e.start.getTime()}${e.end.getTime()}`).join(),
+    () => config.schedules
+  ],
   async () => {
     await nextTick() // Use nextTick to avoid recursive updates.
     // Recalculate overlaps when events change (added, deleted, date change, schedule change).
     recalculateOverlaps()
   },
-  { immediate: true, flush: 'post' } // Use flush: 'post' to prevent infinite updates.
+  { immediate: true, deep: true, flush: 'post' } // Use flush: 'post' to prevent infinite updates.
 )
 
 onBeforeUnmount(async () => {


### PR DESCRIPTION
Hi,
After working a bit more with schedules I unearthed another bug regarding events overlapping.

You can checkout the reproduction here: https://stackblitz.com/edit/vuecal5-events-zbdcslqa?file=src%2FApp.vue
Simply click multiple times the "Toggle Schedules" button. You'll see that sometimes, not always, the check for overlapping event isn't run because the displayed events don't change. This results in events with larger size (because there is only one in the schedule's column) to overlap on the other events.

The changes in this PR aim to force a recheck of the overlapping events whenever the schedules change. I've done that by adding a new source to the watcher of events so that it also checks the schedules. Unfortunally this means that I needed to add a `deep` modifier on the watcher. I'm guessing you were trying to avoid that by the look of the original watch condition. If you have any better ideas I'm open to them!

Have a great day!