### PR TITLE
Add numberOfWeek and support custom #title slot formatting

### DIFF
--- a/src/vue-cal/core/view.js
+++ b/src/vue-cal/core/view.js
@@ -99,6 +99,20 @@ export const useView = ({ config, dateUtils, emit, texts, eventsManager }, vueca
   // Create as many grid cells as defined in the availableViews map (cols * rows).
   const cellsCount = computed(() => cols.value * rows.value)
 
+  /**
+   * {Number|undefined} The number of weeks in the current view.
+   */
+  const numberOfWeek = computed(() => {
+    if (viewId.value === 'week') {
+      return dateUtils.getWeek(
+        firstCellDate.value,
+        config.startWeekOnSunday && !config.hideWeekdays[7]
+      )
+    }
+
+    return undefined;
+  });
+
   const firstCellDate = computed(() => {
     if (viewId.value === 'month') {
       // By default, the month view has 6 rows of 7 days. If the first day of the month is not
@@ -590,6 +604,7 @@ export const useView = ({ config, dateUtils, emit, texts, eventsManager }, vueca
     id: viewId,
     broaderView,
     narrowerView,
+    numberOfWeek,
     title,
     viewDate,
     start,


### PR DESCRIPTION
Problem

In week view, vue-cal provides start and end dates for each week, but:

1. There is no direct way to access the ISO week number for the currently displayed week.
2. The #title slot shows only string of dates with the week number, so users cannot display the week number in a custom format.

Many apps require week numbers in the UI (for business calendars, ERP/CRM integration, or reporting) and want to control how the title is rendered, combining start/end dates with the week number.

Proposal
    - Add a new computed field (or property) such as numberOfWeek.
    - Allow usage in the #title slot so developers can format text freely
    
Fixes #106
