### PR TITLE
feat: compute background events overlap

### DIFF
--- a/src/types/vue-cal.ts
+++ b/src/types/vue-cal.ts
@@ -133,6 +133,7 @@ export interface VueCalConfig {
   snapToInterval?: number, // Snap the event start and end to a specific interval in minutes.
   startWeekOnSunday?: boolean, // Shows Sunday before Monday in days, week and month views.
   stackEvents?: boolean,
+  stackBackgroundEvents?: boolean,
   theme?: boolean | string,
   time?: boolean, // Show or hide the time column.
   timeCellHeight?: number, // In pixels.

--- a/src/vue-cal/core/events.js
+++ b/src/vue-cal/core/events.js
@@ -312,9 +312,9 @@ export const useEvents = vuecal => {
 
   // Will recalculate all the overlaps of the current cell OR schedule.
   // cellEvents will contain only the current schedule events if in a schedule.
-  const getCellOverlappingEvents = (cellStart, cellEnd, allDay) => {
+  const getCellOverlappingEvents = (cellStart, cellEnd, allDay, background = false) => {
     const allDayFilter = config.allDayEvents ? { allDay } : {}
-    const cellEvents = getEventsInRange(cellStart, cellEnd, { background: false, ...allDayFilter })
+    const cellEvents = getEventsInRange(cellStart, cellEnd, { background: background, foreground: !background, ...allDayFilter })
     if (!cellEvents.length) return { cellOverlaps: {}, longestStreak: 0 }
 
     const cellOverlaps = {}
@@ -390,7 +390,7 @@ export const useEvents = vuecal => {
    *                         options.allDay Whether to include all-day events.
    * @returns {Array} Array of events in the range
    */
-  const getEventsInRange = (start, end, { excludeIds = [], schedule = null, background = true, allDay = false } = {}) => {
+  const getEventsInRange = (start, end, { excludeIds = [], schedule = null, background = true, allDay = false, foreground = true } = {}) => {
     // Fast path: if there are no events, return empty array immediately.
     if (!Object.keys(events.value.byId).length) return []
 
@@ -413,6 +413,7 @@ export const useEvents = vuecal => {
       for (const event of Object.values(events.value.byId)) {
         if (!event || excludeSet.has(event._.id)) continue
         if (schedule !== null && schedule !== event.schedule) continue
+        if (foreground === false && !event.background) continue
         if (background === false && event.background) continue
         if (config.allDayEvents && ((allDay && !event.allDay) || (!allDay && event.allDay))) continue
         // Accept events that overlap the range.

--- a/src/vue-cal/core/props-definitions.js
+++ b/src/vue-cal/core/props-definitions.js
@@ -3,6 +3,7 @@ export const minutesInADay = 24 * 60 // Don't do the maths every time.
 export const props = {
   allDayEvents: { type: Boolean, default: false }, // Display all-day events in a fixed top bar on the day, days & week views.
   stackEvents: { type: Boolean, default: false },
+  stackBackgroundEvents: { type: Boolean, default: false },
   clickToNavigate: { type: Boolean, default: undefined }, // Setting to false will force it off on date-picker.
   dark: { type: Boolean, default: false }, // Dark theme.
   datePicker: { type: Boolean, default: false }, // Shorthand for xs: true, views: [month, year, years], clickToNavigate: true.


### PR DESCRIPTION
Hi,

Recently, I needed to create multiple background events for a single day and found that they would stack on each other. After looking into the events processing, I found that they were indeed filtered out. It seemed fine as we don't want them to be detected as overlaps of the foreground events. Therefore, I added a second check which calculates the overlap between background events.

Let me know what you think of this, I'm open to finding another solution if this one doesn't feel right!